### PR TITLE
Change Sequel desc's writing style

### DIFF
--- a/start.rb
+++ b/start.rb
@@ -33,7 +33,7 @@ get '/style.css' do
 end
 
 get '/' do
-  @comments = Comments.order_by(:posted_date.desc)
+  @comments = Comments.order_by(Sequel.desc(:posted_date))
   haml :index
 end
 


### PR DESCRIPTION
日本語で失礼します。
sequel(4.27.0)を用いて、sinatbbsを動かしたところ、アクセス時に以下のエラーが出ました。

```
    2015-10-19 16:17:17 - NoMethodError - undefined method `desc' for :postd_date:Symbol:
```

[ドキュメント](http://sequel.jeremyevans.net/rdoc/classes/Sequel/Dataset.html#method-i-order)(2014-11-20版）のフォーマットに変更したところ、正常にアクセスができました。
Pull Requestのご確認のほど、よろしくお願いします。
